### PR TITLE
fixes error with pr.repository

### DIFF
--- a/polyphemus/batlabrun.py
+++ b/polyphemus/batlabrun.py
@@ -148,8 +148,10 @@ class PolyphemusPlugin(Plugin):
     def execute(self, rc):
         event_name = rc.event.name
         pr = rc.event.data  # pull request object
-        job = pr.repository + (pr.number,)  # job key (owner, repo, number) 
-        jobdir = "${HOME}/" + "--".join(pr.repository + (str(pr.number),))
+        #job = pr.repository + (pr.number,)  # job key (owner, repo, number) 
+        job = pr.base.repo + (pr.number,)  # job key (owner, repo, number) 
+        #jobdir = "${HOME}/" + "--".join(pr.repository + (str(pr.number),))
+        jobdir = "${HOME}/" + "--".join(pr.base.repo + (str(pr.number),))
         jobs = PersistentCache(cachefile=rc.batlab_jobs_cache)
         event = rc.event = Event(name='batlab-status', data={'status': 'error', 
                                  'number': pr.number, 'description': ''})

--- a/polyphemus/githubbase.py
+++ b/polyphemus/githubbase.py
@@ -131,7 +131,8 @@ def set_pull_request_status(pr, state, target_url="", description='', user=None,
         r = gh.repository(*pr[:2])
         pr = gh.pull_request(*pr)
     else:
-        r = gh.repository(*pr.repository)
+        #r = gh.repository(*pr.repository)  Broken on github3.py v0.8+
+        r = gh.repository(*pr.base.repo)
     status = r.create_status(pr.head.sha, state=state, target_url=target_url, 
                              description=description)    
 


### PR DESCRIPTION
fixes error with pr.repository returning ('repos/<owner>', '<repo-name>') rather than ('<owner>', '<repo-name>'). Leaves original version in, but commented out in case of revert needs.

Can @gidden or @zwelchWI take a look please?
