### PR TITLE
escaping $ in NMI_FAIL query

### DIFF
--- a/polyphemus/batlabrun.py
+++ b/polyphemus/batlabrun.py
@@ -34,7 +34,7 @@ curl --form status='{{\"status\":\"pending\",\"number\":{number},\"description\"
 """
 
 post_curl_template = r"""# polyphemus post_all callbacks
-if [ -z $_NMI_STEP_FAILED ]
+if [ -z \$_NMI_STEP_FAILED ]
 then
     curl --form status='{{\"status\":\"success\",\"number\":{number},\"description\":\"build and test completed successfully\"}}' {server_url}:{port}/batlabstatus
 else


### PR DESCRIPTION
post all now reads:

```
#!/bin/bash                                                                                                                                           
# polyphemus post_all callbacks                                                                                                                       
if [ -z $_NMI_STEP_FAILED ]
then
    curl --form status='{"status":"success","number":694,"description":"build and test completed successfully"}' http://cyclus-ci.fuelcycle.org:80/ba\
tlabstatus
else
    curl --form status='{"status":"failure","number":694,"description":"build and test failed"}' http://cyclus-ci.fuelcycle.org:80/batlabstatus
fi
```
