### PR TITLE
Fixed wrong polyphemus reporting and dashboard failure bugs

### DIFF
--- a/polyphemus/batlabrun.py
+++ b/polyphemus/batlabrun.py
@@ -34,7 +34,10 @@ curl --form status='{{\"status\":\"pending\",\"number\":{number},\"description\"
 """
 
 post_curl_template = r"""# polyphemus post_all callbacks
-if [ -z $_NMI_STEP_FAILED ]
+val0=\`grep \"return value 0\" ../../run.log | wc -l\`
+valAny=\`grep \"return value\" ../../run.log | wc -l\`
+
+if [ \$val0 == \$valAny ]
 then
     curl --form status='{{\"status\":\"success\",\"number\":{number},\"description\":\"build and test completed successfully\"}}' {server_url}:{port}/batlabstatus
 else

--- a/polyphemus/dashboard.py
+++ b/polyphemus/dashboard.py
@@ -61,7 +61,7 @@ class PolyphemusPlugin(Plugin):
     _bgcolors = {
         'success': 'rgba(149, 201, 126, 0.6)', 
         'pending': 'rgba(255, 153, 51, 0.6)', 
-        'failed': 'rgba(189, 44, 0, 0.6)', 
+        'failure': 'rgba(189, 44, 0, 0.6)', 
         'error': 'rgba(51, 51, 51, 0.6)',
         }
 


### PR DESCRIPTION
Changed the method of batlab success/failure reporting to use a batlab log file instead of an environment variable.  The resulting dashboard error was caused from using 'failure' as a dictionary key that was using 'failed' as a key.  Check the cyclus dashboard to see 694 is now reporting failure.
